### PR TITLE
xmonad: Use playerctl to handle audio keys

### DIFF
--- a/userspace/xmonad/lib/Nix/Vars.nix.hs
+++ b/userspace/xmonad/lib/Nix/Vars.nix.hs
@@ -1,6 +1,6 @@
 { scripts, alsaUtils, copyq, xautolock
 , xmobar, rofi, libqalculate, st, xmessage, dbus, tmux, rofi-scripts, xbacklight
-, xkbcomp, custom-keymap
+, xkbcomp, custom-keymap, playerctl
 }:
 ''
 module Nix.Vars where
@@ -17,6 +17,7 @@ qalc = "${libqalculate}/bin/qalc"
 xmessage = "${xmessage}/bin/xmessage"
 tmux = "${tmux}/bin/tmux"
 xbacklight = "${xbacklight}/bin/xbacklight"
+playerctl = "${playerctl}/bin/playerctl"
 
 xkbcomp = "${xkbcomp}/bin/xkbcomp"
 customKeymap = "${custom-keymap}"

--- a/userspace/xmonad/lib/XMonad/Config/Kirens/Keys.hs
+++ b/userspace/xmonad/lib/XMonad/Config/Kirens/Keys.hs
@@ -134,9 +134,9 @@ keyConfig actions conf = mkKeymap conf $
   , ("<XF86AudioRaiseVolume>", volumeInc actions)
   , ("<XF86AudioLowerVolume>", volumeDec actions)
   , ("<XF86AudioMute>", volumeToggleMute actions)
-  -- , ("<XF86AudioPlay>", musicPlayPause actions)
-  -- , ("<XF86AudioNext>", musicNext actions)
-  -- , ("<XF86AudioPrev>", musicPrev actions)
+  , ("<XF86AudioPlay>", musicPlayPause actions)
+  , ("<XF86AudioNext>", musicNext actions)
+  , ("<XF86AudioPrev>", musicPrev actions)
   , ("M-p", trackpadEnabledToggle actions)
   , ("<Print>", printScreen actions)
 

--- a/userspace/xmonad/xmonad.nix
+++ b/userspace/xmonad/xmonad.nix
@@ -5,7 +5,7 @@ let
 
   configData = with pkgs; rec {
     inherit
-      alsaUtils copyq xautolock libqalculate dbus tmux;
+      alsaUtils copyq xautolock libqalculate dbus tmux playerctl;
 
     inherit (xorg) xmessage xbacklight xkbcomp;
 


### PR DESCRIPTION
`Previous`, `Play/Pause` and `Next` buttons will now be handled somewhat appropriately by XMonad.

Caveat: If nothing is playing `play/pause` will cause first available music service ordered alphabetically to play.